### PR TITLE
fix: persist session & handle `client_crt` session error if not set

### DIFF
--- a/lxconsole/routes.py
+++ b/lxconsole/routes.py
@@ -142,6 +142,11 @@ def server():
 @app.route("/servers")
 @login_required
 def servers():
+  # Logout and redirect to login if `client_crt` session is not set
+  if 'client_crt' not in session:
+    logout_user()
+    return redirect(url_for('login'))
+  
   return render_template('servers.html', page_title='Servers', page_user_id=current_user.id, page_username=current_user.username, client_crt=session['client_crt'])
 
 @app.route("/simplestreams")
@@ -258,6 +263,7 @@ def login():
         session['otp_next_page'] = request.args.get('next')
         return redirect(url_for('login_otp'))
       else:
+        session.permanent = login_form.remember.data
         login_user(user, remember=login_form.remember.data)
         next_page = request.args.get('next')
 


### PR DESCRIPTION
Make the session permanent if `Remember Me` checkbox is checked, and log the user out if `client_crt` session data is not set.

This will fix #30 